### PR TITLE
Use UMD (Universal Module Definition) pattern to define Mobi Pick

### DIFF
--- a/js/mobipick.js
+++ b/js/mobipick.js
@@ -9,8 +9,16 @@
  *
  * Licensed under MIT license, see MIT-license.txt
  */
-( function( $, undefined ){
-$.widget( "sustainablepace.mobipick", $.mobile.widget, {
+(function( factory ) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define( ['jquery', 'jquery.mobile'], factory );
+	} else {
+		// Browser globals
+		factory( jQuery, jQuery.mobile );
+	}
+}( function( $, $mobile, undefined ){
+$.widget( "sustainablepace.mobipick", $mobile.widget, {
 	options: {
 		date            : null,
 		dateFormat      : "yyyy-MM-dd",
@@ -380,4 +388,4 @@ $.widget( "sustainablepace.mobipick", $.mobile.widget, {
 		);
 	}
 });
-}( jQuery ) );
+}));


### PR DESCRIPTION
Based on the recommended UMD pattern for jQuery plugins
https://github.com/umdjs/umd/blob/master/jqueryPlugin.js

When running in an AMD environment such as RequireJS, the UMD pattern
provides several advantages over the previous technique:
- Allows this module to declare its dependencies (which are jquery
and jquery.mobile) so that the AMD loader will automatically load
those before defining the present module.
- Instead of immediately initializing itself upon execution of the
mobipick.js script, a factory function is registered with the AMD
loader, and the factory function is only run when the mobipick
module is requested by something else.

The lack of dependency declaration can be worked around in RequireJS
using a shim declaration, but the immediate initialization remains
a problem if this module is includes as part of an optimized bundle
(e.g. using r.js). It causes the module to initialize itself too
soon, before jQuery and jQuery.mobile exist.

The UMD pattern retains comtabibility with non-AMD environments:
when AMD is not detected, the factory function is executed right
away, resulting in the same behaviour as before.