### PR TITLE
Supporting date formats other than d m Y

### DIFF
--- a/demo-advanced.html
+++ b/demo-advanced.html
@@ -73,6 +73,9 @@
 			$( "input.mobipick-mm-dd-yyyy" ).mobipick({
 				dateFormat: "MM-dd-yyyy"
 			});
+			$( "input.mobipick-controls-8601-order" ).mobipick({
+				inputOrder: "y m d"
+			});
 
             var buttonPicker = $( "input.mobipick-programmatically", this ).mobipick();
             $( "button.mobipick-programmatically", this ).on( "tap click", function() {
@@ -228,6 +231,20 @@
                 <pre class="brush:xml">&lt;input type="hidden" /&gt;
 &lt;button type="hidden" value="click to open picker"/&gt;&lt;/button&gt;
                 </pre>
+            </div>
+            <div class="demo">
+                <h1>Customize order of controls in popup</h1>
+                <input class="mobipick-controls-8601-order" type="text" />
+				<pre class="brush: js">
+			var picker = $( selector ).mobipick({
+				// dateFormat controls the format of the output string
+				// whereas this controls the order of the controls
+				// in the picker popup.
+				// Default is "d m y"
+				// Here we request ISO 8601 order instead
+				inputOrder: "y m d"
+			});</pre>
+                <pre class="brush:xml">&lt;input type="text" /&gt;</pre>
             </div>
 			Created by Christoph Baudson. Feel free to check out my <a href="http://sustainablepace.net">blog</a>.
 		</div>

--- a/js/mobipick.js
+++ b/js/mobipick.js
@@ -24,6 +24,7 @@ $.widget( "sustainablepace.mobipick", $mobile.widget, {
 		dateFormat      : "yyyy-MM-dd",
 		dateFormatMonth : "yyyy-MM",
 		dateFormatYear  : "yyyy",
+		inputOrder      : "d m y",
 		locale          : "en",
 		intlStdDate     : true,
 		buttonTheme     : "b",
@@ -308,7 +309,12 @@ $.widget( "sustainablepace.mobipick", $mobile.widget, {
 	//
 	// View
 	//
-	_markup: "<div class='mobipick-main'><div class='mobipick-date-formatted'>Date</div><ul class='mobipick-groups'><li><ul><li><a class='mobipick-next-day'>+</a></li><li><input type='text' class='mobipick-input mobipick-day' /></li><li><a class='mobipick-prev-day'>-</a></li></ul></li><li><ul><li><a class='mobipick-next-month'>+</a></li><li><input type='text' class='mobipick-input mobipick-month' /></li><li><a class='mobipick-prev-month'>-</a></li></ul></li><li><ul><li><a class='mobipick-next-year'>+</a></li><li><input type='text' class='mobipick-input mobipick-year' /></li><li><a class='mobipick-prev-year'>-</a></li></ul></li></ul><ul class='mobipick-buttons'><li><a class='mobipick-set'>Set</a></li><li><a class='mobipick-cancel'>Cancel</a></li></ul></div>",
+	_markup_header: "<div class='mobipick-main'><div class='mobipick-date-formatted'>Date</div><ul class='mobipick-groups'>",
+	_markup_d: "<li><ul><li><a class='mobipick-next-day'>+</a></li><li><input type='text' class='mobipick-input mobipick-day' /></li><li><a class='mobipick-prev-day'>-</a></li></ul></li>",
+	_markup_m: "<li><ul><li><a class='mobipick-next-month'>+</a></li><li><input type='text' class='mobipick-input mobipick-month' /></li><li><a class='mobipick-prev-month'>-</a></li></ul></li>",
+	_markup_y: "<li><ul><li><a class='mobipick-next-year'>+</a></li><li><input type='text' class='mobipick-input mobipick-year' /></li><li><a class='mobipick-prev-year'>-</a></li></ul></li>",
+	_markup_trailer: "</ul><ul class='mobipick-buttons'><li><a class='mobipick-set'>Set</a></li><li><a class='mobipick-cancel'>Cancel</a></li></ul></div>",
+
 	_applyTheme: function() {
 		var p       = this._picker,
 		    buttons = {
@@ -330,7 +336,12 @@ $.widget( "sustainablepace.mobipick", $mobile.widget, {
 	},
 	_createView: function() {
 		this.element.attr( "readonly", "readonly" );
-		this._picker = $( this._markup ).popup( this.options.popup );
+		var markup = this._markup_header +
+			this.options.inputOrder.split(" ").map(function(v, i, a) {
+				return this["_markup_" + v];
+			}, this).join("") +
+			this._markup_trailer;
+		this._picker = $( markup ).popup( this.options.popup );
 		$.data( this.element, "mobipick", this );
 		this._applyTheme();
 	},

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -489,6 +489,24 @@ test( "Pull 11", function() {
 	
 	deepEqual( "", this.$mp.val() );
 });
+test( "inputOrder default", function() {
+	var p = this.$mp.mobipick().trigger( "tap" );
+	this.selectDatepickerItems();
+	ok(/mobipick-day.*mobipick-month.*mobipick-year/.test(
+		p.data("sustainablepaceMobipick")._picker[0].innerHTML
+	));
+	this.$cancel.trigger( "tap" );
+});
+test( "inputOrder ISO 8601", function() {
+	var p = this.$mp.mobipick({
+		inputOrder: "y m d"
+	}).trigger( "tap" );
+	this.selectDatepickerItems();
+	ok(/mobipick-year.*mobipick-month.*mobipick-day/.test(
+		p.data("sustainablepaceMobipick")._picker[0].innerHTML
+	));
+	this.$cancel.trigger( "tap" );
+});
 
 asyncTest( "issue 6", function() {
 	expect( 1 );


### PR DESCRIPTION
Although Mobi Pick is quite flexible when it comes to the date format that it produces on output, the layout of the selection control is always d m Y. This seems to be hard coded in the _markup attribute of the widget definition: three <li> elements are defined inside a <ul> element and their order is always day, month, year. I haven't figured out any way to change it short of editing the _markup attribute value. Is there one?

In some locales, notably in Asian languages, the day month year order is not appropriate at all. It really needs to be year month day.

Would you accept a patch to make the order of the elements in _markup configurable through a new option? Or is there already a way to do this which I missed?